### PR TITLE
Disable generation of MD2Formatter.java

### DIFF
--- a/de.wwu.md2.framework/src/de/wwu/md2/framework/GenerateMD2.mwe2
+++ b/de.wwu.md2.framework/src/de/wwu/md2/framework/GenerateMD2.mwe2
@@ -88,7 +88,9 @@ Workflow {
             }
 
             // formatter API
-            fragment = formatting.FormatterFragment {}
+            fragment = formatting.FormatterFragment {
+                generateStub = false
+            }
 
             // labeling API
             fragment = labeling.LabelProviderFragment {}


### PR DESCRIPTION
Removing the stub generation will stop generation of the MD2Formatter.java class into de.wwu.md2.framework.formatting.
