### PR TITLE
Bug: Initialize entities in models

### DIFF
--- a/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/mapapps/EntityClass.xtend
+++ b/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/mapapps/EntityClass.xtend
@@ -85,7 +85,7 @@ class EntityClass {
 			ReferencedType: {
 				val element = type.element
 				switch element {
-					Entity: '''null'''
+					Entity: '''this._typeFactory.create("«element.name.toFirstUpper»", null)'''
 					Enum: {
 						val defaultValue = type.params.filter(AttrEnumDefault).head
 						'''this._typeFactory.create("«element.name.toFirstUpper»", "«IF defaultValue != null»VALUE«element.enumBody.elements.indexOf(defaultValue.value)»«ELSE»VALUE0«ENDIF»")'''


### PR DESCRIPTION
This is a quick fix to not initialize entities with `null` in our models.
Later on we probably also want to be able to set the entity to an already existing entity, but for the time being this relieves us from manually changing this line every time we regenerate the project.
