### PR TITLE
Generate multiple apps

### DIFF
--- a/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/backend/BackendGenerator.xtend
+++ b/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/backend/BackendGenerator.xtend
@@ -31,25 +31,23 @@ class BackendGenerator extends AbstractPlatformGenerator {
 		/////////////////////////////////////////
 		
 		// Generate models, web services and beans
-		dataContainer.models.forEach [model |
-			model.modelElements.filter(typeof(ModelElement)).forEach[modelElement |
-				fsa.generateFile(rootFolder + "/src/" + rootFolder.replace('.', '/') + "/models/"
-					+ modelElement.name.toFirstUpper + ".java", createModel(rootFolder, modelElement))
-				
-				val isUsedInRemoteContentProvider = dataContainer.contentProviders.exists[ c |
-					c.type instanceof ReferencedModelType
-					&& !c.local
-					&& (c.type as ReferencedModelType).entity.identityEquals(modelElement)
-				]
-				
-				// web services and beans for an entity are only generated if they are used in any remote content provider
-				if(modelElement instanceof Entity && isUsedInRemoteContentProvider) {
-					fsa.generateFile(rootFolder + "/src/" + rootFolder.replace('.', '/') + "/ws/"
-						+ modelElement.name.toFirstUpper + "WS.java", createEntityWS(rootFolder, modelElement as Entity))
-					fsa.generateFile(rootFolder + "/src/" + rootFolder.replace('.', '/') + "/beans/"
-						+ modelElement.name.toFirstUpper + "Bean.java", createEntityBean(rootFolder, modelElement as Entity))
-				}
+		dataContainer.model.modelElements.filter(typeof(ModelElement)).forEach[modelElement |
+			fsa.generateFile(rootFolder + "/src/" + rootFolder.replace('.', '/') + "/models/"
+				+ modelElement.name.toFirstUpper + ".java", createModel(rootFolder, modelElement))
+			
+			val isUsedInRemoteContentProvider = dataContainer.contentProviders.exists[ c |
+				c.type instanceof ReferencedModelType
+				&& !c.local
+				&& (c.type as ReferencedModelType).entity.identityEquals(modelElement)
 			]
+			
+			// web services and beans for an entity are only generated if they are used in any remote content provider
+			if(modelElement instanceof Entity && isUsedInRemoteContentProvider) {
+				fsa.generateFile(rootFolder + "/src/" + rootFolder.replace('.', '/') + "/ws/"
+					+ modelElement.name.toFirstUpper + "WS.java", createEntityWS(rootFolder, modelElement as Entity))
+				fsa.generateFile(rootFolder + "/src/" + rootFolder.replace('.', '/') + "/beans/"
+					+ modelElement.name.toFirstUpper + "Bean.java", createEntityBean(rootFolder, modelElement as Entity))
+			}
 		]
 		
 		// Generate datatype wrapper

--- a/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/mapapps/AppClass.xtend
+++ b/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/mapapps/AppClass.xtend
@@ -8,10 +8,10 @@ class AppClass {
 	
 	def static String generateAppJson(DataContainer dataContainer) '''
 {
-    "appName": "«dataContainer.apps.head.appName»",
+    "appName": "«dataContainer.app.appName»",
     "properties": {
-        "id": "«dataContainer.apps.head.name»",
-        "title": "«dataContainer.apps.head.appName»"
+        "id": "«dataContainer.app.name»",
+        "title": "«dataContainer.app.appName»"
     },
     
     "load": {
@@ -47,8 +47,8 @@ class AppClass {
             "md2_models",
             "md2_content_providers",
             
-            «FOR elem : dataContainer.workflowElements SEPARATOR ","»
-            "«elem.bundleName»"
+            «FOR elem : dataContainer.workflowElementsForApp SEPARATOR ","»
+                "«elem.bundleName»"
             «ENDFOR»
         ],
         
@@ -121,8 +121,8 @@ class AppClass {
 	    "md2_content_providers": {},
 	    "md2_workflow" : {},
 	    
-	    «FOR elem : dataContainer.workflowElements SEPARATOR ","»
-	    "«elem.bundleName»": {}
+	    «FOR elem : dataContainer.workflowElementsForApp SEPARATOR ","»
+	       "«elem.bundleName»": {}
 	    «ENDFOR»
 	}
 	'''

--- a/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/mapapps/AppClass.xtend
+++ b/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/mapapps/AppClass.xtend
@@ -3,15 +3,16 @@ package de.wwu.md2.framework.generator.mapapps
 import de.wwu.md2.framework.generator.util.DataContainer
 
 import static extension de.wwu.md2.framework.generator.mapapps.util.MD2MapappsUtil.*
+import de.wwu.md2.framework.mD2.App
 
 class AppClass {
 	
-	def static String generateAppJson(DataContainer dataContainer) '''
+	def static String generateAppJson(DataContainer dataContainer, App app) '''
 {
-    "appName": "«dataContainer.app.appName»",
+    "appName": "«app.appName»",
     "properties": {
-        "id": "«dataContainer.app.name»",
-        "title": "«dataContainer.app.appName»"
+        "id": "«app.name»",
+        "title": "«app.appName»"
     },
     
     "load": {
@@ -47,7 +48,7 @@ class AppClass {
             "md2_models",
             "md2_content_providers",
             
-            «FOR elem : dataContainer.workflowElementsForApp SEPARATOR ","»
+            «FOR elem : dataContainer.workflowElementsForApp(app) SEPARATOR ","»
                 "«elem.bundleName»"
             «ENDFOR»
         ],
@@ -115,13 +116,13 @@ class AppClass {
 	
 	// Generate the "allowed-bundle" string for each workflow element
 	
-	def static String generateBundleJson(DataContainer dataContainer) '''
+	def static String generateBundleJson(DataContainer dataContainer, App app) '''
 	{
 	    "md2_models": {},
 	    "md2_content_providers": {},
 	    "md2_workflow" : {},
 	    
-	    «FOR elem : dataContainer.workflowElementsForApp SEPARATOR ","»
+	    «FOR elem : dataContainer.workflowElementsForApp(app) SEPARATOR ","»
 	       "«elem.bundleName»": {}
 	    «ENDFOR»
 	}

--- a/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/mapapps/ContentProviderClass.xtend
+++ b/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/mapapps/ContentProviderClass.xtend
@@ -15,12 +15,13 @@ import static de.wwu.md2.framework.generator.mapapps.Expressions.*
 
 import static extension de.wwu.md2.framework.generator.util.MD2GeneratorUtil.*
 import de.wwu.md2.framework.generator.util.DataContainer
+import de.wwu.md2.framework.mD2.App
 
 class ContentProviderClass {
 	
-	def static String generateContentProvider(ContentProvider contentProvider, DataContainer dataContainer) '''
+	def static String generateContentProvider(ContentProvider contentProvider, DataContainer dataContainer, App app) '''
 		«val imports = newLinkedHashMap("declare" -> "dojo/_base/declare", "ContentProvider" -> "md2_runtime/contentprovider/ContentProvider")»
-		«val body = generateContentProviderBody(contentProvider, dataContainer, imports)»
+		«val body = generateContentProviderBody(contentProvider, dataContainer, app, imports)»
 		define([
 			«FOR key : imports.keySet SEPARATOR ","»
 				"«imports.get(key)»"
@@ -32,7 +33,7 @@ class ContentProviderClass {
 		});
 	'''
 	
-	def static String generateContentProviderBody(ContentProvider contentProvider, DataContainer dataContainer, Map<String, String> imports) '''
+	def static String generateContentProviderBody(ContentProvider contentProvider, DataContainer dataContainer, App app, Map<String, String> imports) '''
 		/**
 		 * ContentProvider Factory
 		 */
@@ -45,7 +46,7 @@ class ContentProviderClass {
 				«ELSE»
 					«generateRemoteBody(contentProvider)»
 				«ENDIF»
-				var appId = "md2_«dataContainer.app.appName»";
+				var appId = "md2_«app.appName»";
 				
 				«IF contentProvider.filter»
 					var filter = function() {

--- a/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/mapapps/ContentProviderClass.xtend
+++ b/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/mapapps/ContentProviderClass.xtend
@@ -10,7 +10,6 @@ import de.wwu.md2.framework.mD2.WhereClauseNot
 import de.wwu.md2.framework.mD2.WhereClauseOr
 import java.util.Map
 import java.util.Set
-import org.eclipse.emf.ecore.resource.ResourceSet
 
 import static de.wwu.md2.framework.generator.mapapps.Expressions.*
 
@@ -19,9 +18,9 @@ import de.wwu.md2.framework.generator.util.DataContainer
 
 class ContentProviderClass {
 	
-	def static String generateContentProvider(ContentProvider contentProvider, DataContainer dataContainer, ResourceSet processedInput) '''
+	def static String generateContentProvider(ContentProvider contentProvider, DataContainer dataContainer) '''
 		«val imports = newLinkedHashMap("declare" -> "dojo/_base/declare", "ContentProvider" -> "md2_runtime/contentprovider/ContentProvider")»
-		«val body = generateContentProviderBody(contentProvider, dataContainer, processedInput, imports)»
+		«val body = generateContentProviderBody(contentProvider, dataContainer, imports)»
 		define([
 			«FOR key : imports.keySet SEPARATOR ","»
 				"«imports.get(key)»"
@@ -33,7 +32,7 @@ class ContentProviderClass {
 		});
 	'''
 	
-	def static String generateContentProviderBody(ContentProvider contentProvider, DataContainer dataContainer, ResourceSet processedInput, Map<String, String> imports) '''
+	def static String generateContentProviderBody(ContentProvider contentProvider, DataContainer dataContainer, Map<String, String> imports) '''
 		/**
 		 * ContentProvider Factory
 		 */
@@ -46,7 +45,7 @@ class ContentProviderClass {
 				«ELSE»
 					«generateRemoteBody(contentProvider)»
 				«ENDIF»
-				var appId = "md2_«dataContainer.workflows?.head.apps?.head.appName»";
+				var appId = "md2_«dataContainer.app.appName»";
 				
 				«IF contentProvider.filter»
 					var filter = function() {

--- a/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/mapapps/EventHandlerClass.xtend
+++ b/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/mapapps/EventHandlerClass.xtend
@@ -1,7 +1,6 @@
 package de.wwu.md2.framework.generator.mapapps
 
 import de.wwu.md2.framework.generator.util.DataContainer
-import org.eclipse.emf.ecore.resource.ResourceSet
 import de.wwu.md2.framework.mD2.CustomAction
 import de.wwu.md2.framework.mD2.EventBindingTask
 import de.wwu.md2.framework.mD2.WorkflowElement
@@ -13,7 +12,7 @@ import org.eclipse.xtend2.lib.StringConcatenation
 
 class EventHandlerClass {
 
-    def static String generateWorkflowEventHandler(DataContainer dataContainer, ResourceSet processedInput) {
+    def static String generateWorkflowEventHandler(DataContainer dataContainer) {
 
         // TODO: get the right values here...
         '''
@@ -37,7 +36,7 @@ class EventHandlerClass {
                     
                     handleEvent: function(event, workflowelement) {
                       if
-                    «FOR wfe : dataContainer.workflowElements SEPARATOR StringConcatenation::DEFAULT_LINE_DELIMITER + "else if"»
+                    «FOR wfe : dataContainer.workflowElementsForApp SEPARATOR StringConcatenation::DEFAULT_LINE_DELIMITER + "else if"»
                         «FOR event : getEventsFromWorkflowElement(wfe) SEPARATOR StringConcatenation::DEFAULT_LINE_DELIMITER + "else if"»
                             (event === "«event.name»" && workflowelement === "«wfe.name»")
                             {  this.instance.controllers.get("md2.wfe.«wfe.name».Controller").closeWindow();
@@ -83,7 +82,7 @@ class EventHandlerClass {
 	 */
     def private static WorkflowElement getNextWorkflowElement(DataContainer dataContainer, WorkflowElement wfe,
         WorkflowEvent e) {
-        var wfes = dataContainer.workflows.head.workflowElementEntries
+        var wfes = dataContainer.workflow.workflowElementEntries
 
         for (WorkflowElementEntry entry : wfes) {
             if (entry.workflowElement.equals(wfe)) {

--- a/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/mapapps/EventHandlerClass.xtend
+++ b/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/mapapps/EventHandlerClass.xtend
@@ -9,10 +9,11 @@ import de.wwu.md2.framework.mD2.FireEventAction
 import de.wwu.md2.framework.mD2.WorkflowElementEntry
 import de.wwu.md2.framework.mD2.WorkflowEvent
 import org.eclipse.xtend2.lib.StringConcatenation
+import de.wwu.md2.framework.mD2.App
 
 class EventHandlerClass {
 
-    def static String generateWorkflowEventHandler(DataContainer dataContainer) {
+    def static String generateWorkflowEventHandler(DataContainer dataContainer, App app) {
 
         // TODO: get the right values here...
         '''
@@ -36,7 +37,7 @@ class EventHandlerClass {
                     
                     handleEvent: function(event, workflowelement) {
                       if
-                    «FOR wfe : dataContainer.workflowElementsForApp SEPARATOR StringConcatenation::DEFAULT_LINE_DELIMITER + "else if"»
+                    «FOR wfe : dataContainer.workflowElementsForApp(app) SEPARATOR StringConcatenation::DEFAULT_LINE_DELIMITER + "else if"»
                         «FOR event : getEventsFromWorkflowElement(wfe) SEPARATOR StringConcatenation::DEFAULT_LINE_DELIMITER + "else if"»
                             (event === "«event.name»" && workflowelement === "«wfe.name»")
                             {  this.instance.controllers.get("md2.wfe.«wfe.name».Controller").closeWindow();

--- a/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/mapapps/ManifestJson.xtend
+++ b/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/mapapps/ManifestJson.xtend
@@ -28,18 +28,16 @@ import de.wwu.md2.framework.mD2.Tooltip
 import de.wwu.md2.framework.mD2.ViewGUIElement
 import de.wwu.md2.framework.mD2.WidthParam
 import de.wwu.md2.framework.mD2.WorkflowElement
-import org.eclipse.emf.ecore.resource.ResourceSet
 import org.eclipse.xtext.xbase.lib.Pair
 
 import static extension de.wwu.md2.framework.generator.mapapps.util.MD2MapappsUtil.*
 import static extension de.wwu.md2.framework.generator.util.MD2GeneratorUtil.*
 import static extension de.wwu.md2.framework.util.StringExtensions.*
-import de.wwu.md2.framework.mD2.WorkflowElementReference
 
 class ManifestJson {
 		
-	def static String generateManifestJsonForModels(DataContainer dataContainer, ResourceSet processedInput) {
-		var appName = dataContainer.workflows?.head.apps?.head.appName
+	def static String generateManifestJsonForModels(DataContainer dataContainer) {
+		var appName = dataContainer.app.appName
 		'''
 			{
 			    «generateBundlePropertiesSnippet(dataContainer, "model")»
@@ -50,7 +48,7 @@ class ManifestJson {
 			    ],
 			    "Components": [
 					«val snippets = newArrayList(
-						generateModelsSnippet(dataContainer, processedInput)
+						generateModelsSnippet(dataContainer)
 					)»
 					«FOR snippet : snippets.filter(s | !s.toString.trim.empty) SEPARATOR ","»
 						«snippet»
@@ -59,8 +57,8 @@ class ManifestJson {
 			}
 		'''
 	}
-	def static String generateManifestJsonForContentProviders(DataContainer dataContainer, ResourceSet processedInput) {
-		var appName = dataContainer.workflows?.head.apps?.head.appName
+	def static String generateManifestJsonForContentProviders(DataContainer dataContainer) {
+		var appName = dataContainer.app.appName
 		'''
 			{
 				«generateBundlePropertiesSnippet(dataContainer, "content_provider")»
@@ -81,7 +79,7 @@ class ManifestJson {
 				],
 				"Components": [
 					«val snippets = newArrayList(
-						generateContentProvidersSnippet(dataContainer, processedInput)
+						generateContentProvidersSnippet(dataContainer)
 					)»
 					«FOR snippet : snippets.filter(s | !s.toString.trim.empty) SEPARATOR ","»
 						«snippet»
@@ -94,11 +92,11 @@ class ManifestJson {
 	/**
 	 * Generates manifest.json code for WorkflowElements.
 	 */
-	def static String generateManifestJsonForWorkflowElement(WorkflowElement workflowElement, DataContainer dataContainer, ResourceSet processedInput) {
-		var appName = dataContainer.workflows?.head.apps?.head.appName
+	def static String generateManifestJsonForWorkflowElement(WorkflowElement workflowElement, DataContainer dataContainer) {
+		var appName = dataContainer.app.appName
 		'''
 			{
-				"Bundle-SymbolicName": "«workflowElement.bundleName»", //TODO:"md2_wfe_«processedInput.getBasePackageName.split("\\.").reduce[ s1, s2 | s1 + "_" + s2]»"
+				"Bundle-SymbolicName": "«workflowElement.bundleName»",
 				"Bundle-Version": "«dataContainer.main.appVersion»",
 				"Bundle-Name": "Workflow element «workflowElement.name»",
 				"Bundle-Description": "Generated MD2 workflow element bundle: «workflowElement.name» of «appName»",
@@ -120,10 +118,10 @@ class ManifestJson {
 				],
 				"Components": [
 					«val snippets = newArrayList(
-						generateConfigurationSnippet(workflowElement, dataContainer, processedInput),
-						generateCustomActionsSnippet(workflowElement, dataContainer, processedInput),
-						generateControllerSnippet(workflowElement, dataContainer, processedInput),
-						generateToolSnippet(workflowElement, dataContainer, processedInput)
+						generateConfigurationSnippet(workflowElement, dataContainer),
+						generateCustomActionsSnippet(workflowElement, dataContainer),
+						generateControllerSnippet(workflowElement, dataContainer),
+						generateToolSnippet(workflowElement, dataContainer)
 					)»
 					«FOR snippet : snippets.filter(s | !s.toString.trim.empty) SEPARATOR ","»
 						«snippet»
@@ -133,8 +131,8 @@ class ManifestJson {
 		'''
 	}
 	
-	def static String generateManifestJsonForWorkflowHandler(DataContainer dataContainer, ResourceSet processedInput) {
-		var appName = dataContainer.workflows?.head.apps?.head.appName;
+	def static String generateManifestJsonForWorkflowHandler(DataContainer dataContainer) {
+		var appName = dataContainer.app.appName
 		'''
 			{
 				«generateBundlePropertiesSnippet(dataContainer, "workflow")»
@@ -165,29 +163,28 @@ class ManifestJson {
 	
 	
 	def private static generateBundlePropertiesSnippet(DataContainer dataContainer, String type){
-	var appName = dataContainer.workflows?.head.apps?.head.appName;
+        var appName = dataContainer.app.appName
 				
-	'''«IF (type=="workflow")»
-		"Bundle-SymbolicName": "md2_workflow",
-		"Bundle-Name": "«appName» «type»",
-		"Bundle-Description": "Generated MD2 bundle: «type» of «appName»",
-		«ELSE»
-		"Bundle-SymbolicName": "md2_«type»s",
-		"Bundle-Name": "«appName» «type»s",
-		"Bundle-Description": "Generated MD2 bundle: «type»s of «appName»",
-		«ENDIF»"Bundle-Version": "2.0",
-"Bundle-Localization": [],
-"Bundle-Main": "",'''
-		
+        '''«IF (type=="workflow")»
+            "Bundle-SymbolicName": "md2_workflow",
+            "Bundle-Name": "«appName» «type»",
+            "Bundle-Description": "Generated MD2 bundle: «type» of «appName»",
+    	«ELSE»
+            "Bundle-SymbolicName": "md2_«type»s",
+            "Bundle-Name": "«appName» «type»s",
+            "Bundle-Description": "Generated MD2 bundle: «type»s of «appName»",
+        «ENDIF»"Bundle-Version": "2.0",
+        "Bundle-Localization": [],
+        "Bundle-Main": "",'''		
 	}
 	
-	def private static String generateConfigurationSnippet(WorkflowElement workflowElement, DataContainer dataContainer, ResourceSet processedInput) {
-	    var appName = dataContainer.workflows?.head.apps?.head.appName;
+	def private static String generateConfigurationSnippet(WorkflowElement workflowElement, DataContainer dataContainer) {
+	    var appName = dataContainer.app.appName
 		'''
 			{
 				"name": "MD2«workflowElement.name»",//TODO: processedInput.getBasePackageName.split("\\.").last.toFirstUpper
 				"impl": "ct/Stateful",
-				"provides": ["md2.wfe.«workflowElement.name».AppDefinition"], //TODO: «processedInput.getBasePackageName»
+				"provides": ["md2.wfe.«workflowElement.name».AppDefinition"],
 				"propertiesConstructor": true,
 				"properties": {
 				    "appId": "md2_«appName»",
@@ -200,7 +197,7 @@ class ManifestJson {
 								"name": "«view.name»",
 								"dataForm": {
 									"dataform-version": "1.0.0",
-									«getViewElement(view, processedInput, false)»
+									«getViewElement(view, false)»
 								}
 							}
 						«ENDFOR»
@@ -210,7 +207,7 @@ class ManifestJson {
 		'''
 	}
 	
-	def static generateCustomActionsSnippet(WorkflowElement workflowElement, DataContainer dataContainer, ResourceSet processedInput) '''
+	def static generateCustomActionsSnippet(WorkflowElement workflowElement, DataContainer dataContainer) '''
 		{
 			"name": "CustomActions",
 			"provides": ["md2.wfe.«workflowElement.name».CustomActions"], //TODO: processedInput.getBasePackageName
@@ -218,22 +215,22 @@ class ManifestJson {
 		}
 	'''
 	
-	def static generateModelsSnippet(DataContainer dataContainer, ResourceSet processedInput) '''
+	def static generateModelsSnippet(DataContainer dataContainer) '''
 		{
 			"name": "Models",
-			"provides": ["md2.app.«dataContainer.workflows?.head.apps?.head.appName».Models"],
+			"provides": ["md2.app.«dataContainer.app.appName».Models"],
 			"instanceFactory": true
 		}
 	'''
 	
-	def static generateContentProvidersSnippet(DataContainer dataContainer, ResourceSet processedInput) {
-		var uri = dataContainer.workflows?.head.apps?.head?.defaultConnection?.uri
+	def static generateContentProvidersSnippet(DataContainer dataContainer) {
+		var uri = dataContainer.app.defaultConnection?.uri
 		'''
 			«FOR contentProvider : dataContainer.contentProviders SEPARATOR ","»
 				{
 					"name": "«contentProvider.name.toFirstUpper»Provider",
 					"impl": "./contentproviders/«contentProvider.name.toFirstUpper»",
-					"provides": ["md2.app.«dataContainer.workflows?.head.apps?.head.appName».ContentProvider"],
+					"provides": ["md2.app.«dataContainer.app.appName».ContentProvider"],
 					«IF !contentProvider.local»
 						"propertiesConstructor": true,
 						"properties": {
@@ -257,9 +254,9 @@ class ManifestJson {
 		'''
 	}
 	
-	def static generateControllerSnippet(WorkflowElement workflowElement, DataContainer dataContainer, ResourceSet processedInput) 
+	def static generateControllerSnippet(WorkflowElement workflowElement, DataContainer dataContainer) 
 	{
-	var appName = dataContainer.workflows?.head.apps?.head.appName;
+	var appName = dataContainer.app.appName;
 	'''
 		{
 			"name": "Controller",
@@ -301,8 +298,8 @@ class ManifestJson {
 	 * The title of the mapapps tool within the application is set to its startable
 	 * alias.
 	 */
-	def static generateToolSnippet(WorkflowElement workflowElement, DataContainer dataContainer, ResourceSet processedInput) {
-		val wfeReferences = processedInput.allContents.filter(typeof (WorkflowElementReference)).filter[it.startable == true]
+	def static generateToolSnippet(WorkflowElement workflowElement, DataContainer dataContainer) {
+		val wfeReferences = dataContainer.app.workflowElements.filter[it.startable == true]
 		val startableWFE = wfeReferences.filter[it.workflowElementReference.name == workflowElement.name].toList
 		var isStartable = (startableWFE.size == 1)
 		
@@ -353,7 +350,7 @@ class ManifestJson {
 	 * Container Elements
 	 ***************************************************************/
 	
-	def private static dispatch String getViewElement(GridLayoutPane gridLayout, ResourceSet processedInput, boolean isSubView) '''
+	def private static dispatch String getViewElement(GridLayoutPane gridLayout, boolean isSubView) '''
 		"type": "md2gridpanel",
 		"cols": "«gridLayout.params.filter(typeof(GridLayoutPaneColumnsParam)).head.value»",
 		"valueClass": "layoutCell",
@@ -363,15 +360,15 @@ class ManifestJson {
 			«FOR element : gridLayout.elements.filter(typeof(ViewGUIElement)) SEPARATOR ","»
 				{
 					«switch element {
-						ContentElement: getViewElement(element, processedInput)
-						ContainerElement: getViewElement(element, processedInput, false)
+						ContentElement: getViewElement(element)
+						ContainerElement: getViewElement(element, false)
 					}»
 				}
 			«ENDFOR»
 		]
 	'''
 	
-	def private static dispatch String getViewElement(TabbedAlternativesPane tabbedPane, ResourceSet processedInput, boolean isSubView) '''
+	def private static dispatch String getViewElement(TabbedAlternativesPane tabbedPane, boolean isSubView) '''
 		"type": "tabpanel",
 		"valueClass": "layoutCell",
 		«generateStyle(null, "width" -> '''100%''')»,
@@ -380,13 +377,13 @@ class ManifestJson {
 			«FOR element : tabbedPane.elements.filter(typeof(ContainerElement)) SEPARATOR ","»
 				{
 					"title": "«element.tabName»",
-					«getViewElement(element, processedInput, true)»
+					«getViewElement(element, true)»
 				}
 			«ENDFOR»
 		]
 	'''
 	
-	def private static dispatch String getViewElement(AlternativesPane alternativesPane, ResourceSet processedInput, boolean isSubView) '''
+	def private static dispatch String getViewElement(AlternativesPane alternativesPane, boolean isSubView) '''
 		"type": "stackcontainer",
 		"valueClass": "layoutCell",
 		«generateStyle(null, "width" -> '''«alternativesPane.params.filter(typeof(WidthParam)).head.width»%''')»,
@@ -394,7 +391,7 @@ class ManifestJson {
 		"children": [
 			«FOR element : alternativesPane.elements.filter(typeof(ContainerElement)) SEPARATOR ","»
 				{
-					«getViewElement(element, processedInput, true)»
+					«getViewElement(element, true)»
 				}
 			«ENDFOR»
 		]
@@ -405,27 +402,27 @@ class ManifestJson {
 	 * Content Elements => Various
 	 ***************************************************************/
 	 
-	def private static dispatch String getViewElement(Image image, ResourceSet processedInput) '''
+	def private static dispatch String getViewElement(Image image) '''
 		"type": "simpleimage",
-		"src": "md2_app_«processedInput.getBasePackageName.split("\\.").reduce[ s1, s2 | s1 + "_" + s2]»:./resources/«image.src»",
+		"src": "md2_app_", //TODO: fix url
 		«IF image.imgWidth > 0»"imgW": «image.imgWidth»,«ENDIF»
 		«IF image.imgHeight > 0»"imgH": «image.imgHeight»,«ENDIF»
 		«generateStyle(null, "width" -> '''«image.width»%''')»
 	'''
 	
-	def private static dispatch String getViewElement(Spacer spacer, ResourceSet processedInput) '''
+	def private static dispatch String getViewElement(Spacer spacer) '''
 		"type": "spacer",
 		«generateStyle(null, "width" -> '''«spacer.width»%''')»
 	'''
 	
-	def private static dispatch String getViewElement(Button button, ResourceSet processedInput) '''
+	def private static dispatch String getViewElement(Button button) '''
 		"type": "button",
 		"title": "«button.text.escape»",
 		"field": "«getName(button)»",
 		«generateStyle(button.style, "width" -> '''«button.width»%''')»
 	'''
 	
-	def private static dispatch String getViewElement(Label label, ResourceSet processedInput) '''
+	def private static dispatch String getViewElement(Label label) '''
 		"type": "textoutput",
 		"datatype": "string",
 		"field": "«getName(label)»",
@@ -433,7 +430,7 @@ class ManifestJson {
 		«generateStyle(label.style, "width" -> '''«label.width»%''')»
 	'''
 	
-	def private static dispatch String getViewElement(Tooltip tooltip, ResourceSet processedInput) '''
+	def private static dispatch String getViewElement(Tooltip tooltip) '''
 		"type": "tooltipicon",
 		"datatype": "string",
 		"field": "«getName(tooltip)»",
@@ -446,63 +443,63 @@ class ManifestJson {
 	 * Content Elements => Input
 	 ***************************************************************/
 	
-	def private static dispatch String getViewElement(BooleanInput input, ResourceSet processedInput) '''
+	def private static dispatch String getViewElement(BooleanInput input) '''
 		"type": "checkbox",
 		"datatype": "boolean",
 		"field": "«getName(input)»",
 		«generateStyle(null, "width" -> '''«input.width»%''')»
 	'''
 	
-	def private static dispatch String getViewElement(TextInput input, ResourceSet processedInput) '''
+	def private static dispatch String getViewElement(TextInput input) '''
 		"type": "textbox",
 		"datatype": "string",
 		"field": "«getName(input)»",
 		«generateStyle(null, "width" -> '''«input.width»%''')»
 	'''
 	
-	def private static dispatch String getViewElement(IntegerInput input, ResourceSet processedInput) '''
+	def private static dispatch String getViewElement(IntegerInput input) '''
 		"type": "numberspinner",
 		"datatype": "integer",
 		"field": "«getName(input)»",
 		«generateStyle(null, "width" -> '''«input.width»%''')»
 	'''
 	
-	def private static dispatch String getViewElement(NumberInput input, ResourceSet processedInput) '''
+	def private static dispatch String getViewElement(NumberInput input) '''
 		"type": "numbertextbox",
 		"datatype": "float",
 		"field": "«getName(input)»",
 		«generateStyle(null, "width" -> '''«input.width»%''')»
 	'''
 	
-	def private static dispatch String getViewElement(DateInput input, ResourceSet processedInput) '''
+	def private static dispatch String getViewElement(DateInput input) '''
 		"type": "datetextbox",
 		"datatype": "date",
 		"field": "«getName(input)»",
 		«generateStyle(null, "width" -> '''«input.width»%''')»
 	'''
 	
-	def private static dispatch String getViewElement(TimeInput input, ResourceSet processedInput) '''
+	def private static dispatch String getViewElement(TimeInput input) '''
 		"type": "timetextbox",
 		"datatype": "time",
 		"field": "«getName(input)»",
 		«generateStyle(null, "width" -> '''«input.width»%''')»
 	'''
 	
-	def private static dispatch String getViewElement(DateTimeInput input, ResourceSet processedInput) '''
+	def private static dispatch String getViewElement(DateTimeInput input) '''
 		"type": "datetimebox",
 		"datatype": "datetime",
 		"field": "«getName(input)»",
 		«generateStyle(null, "width" -> '''«input.width»%''')»
 	'''
 	
-	def private static dispatch String getViewElement(OptionInput input, ResourceSet processedInput) '''
+	def private static dispatch String getViewElement(OptionInput input) '''
 		"type": "selectbox",
 		"datatype": "«input.enumReference.name.toFirstUpper»",
 		"field": "«getName(input)»",
 		«generateStyle(null, "width" -> '''«input.width»%''')»
 	'''
 	
-	def private static dispatch String getViewElement(EntitySelector input, ResourceSet processedInput) '''
+	def private static dispatch String getViewElement(EntitySelector input) '''
 		// TODO
 	'''
 	

--- a/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/mapapps/MapAppsGenerator.xtend
+++ b/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/mapapps/MapAppsGenerator.xtend
@@ -29,8 +29,7 @@ class MapAppsGenerator extends AbstractPlatformGenerator {
 		
 		for(app : dataContainer.apps){
 		    		    		    
-		    //TODO: fix paths
-		    val rootFolder = rootFolder + "/" + app.name
+		    val rootFolder = rootFolder + "/md2_app_" + app.name
 		    val bundlesRootFolder = rootFolder + "/bundles"
 		    
 		    // Copy static map.apps files (map layers)
@@ -136,7 +135,8 @@ class MapAppsGenerator extends AbstractPlatformGenerator {
 	}
 	
 	override getDefaultSubfolder() {
-		"md2_app_" + processedInput.getBasePackageName.split("\\.").reduce[ s1, s2 | s1 + "_" + s2]
+		//"md2_app_" + processedInput.getBasePackageName.split("\\.").reduce[ s1, s2 | s1 + "_" + s2]
+		return null
 	}
 	
 }

--- a/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/mapapps/MapAppsGenerator.xtend
+++ b/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/mapapps/MapAppsGenerator.xtend
@@ -21,15 +21,14 @@ import static extension de.wwu.md2.framework.generator.util.MD2GeneratorUtil.*
 import static extension de.wwu.md2.framework.util.StringExtensions.*
 import static extension de.wwu.md2.framework.generator.mapapps.util.MD2MapappsUtil.*
 import static de.wwu.md2.framework.util.MD2Util.*
+import de.wwu.md2.framework.mD2.App
 
 class MapAppsGenerator extends AbstractPlatformGenerator {
 	
 	override doGenerate(IExtendedFileSystemAccess fsa) {
 		
 		for(app : dataContainer.apps){
-		    
-		    dataContainer.app = app
-		    		    
+		    		    		    
 		    //TODO: fix paths
 		    val rootFolder = rootFolder + "/" + app.name
 		    val bundlesRootFolder = rootFolder + "/bundles"
@@ -39,18 +38,18 @@ class MapAppsGenerator extends AbstractPlatformGenerator {
             fsa.generateFileFromInputStream(getSystemResource("/mapapps/services.json"), rootFolder + "/services.json")
             
             // Generate app-specific app.json and bundles.json files
-            fsa.generateFile(rootFolder + "/app.json", generateAppJson(dataContainer).tabsToSpaces(4))
-            fsa.generateFile(bundlesRootFolder + "/bundles.json", generateBundleJson(dataContainer).tabsToSpaces(4))
+            fsa.generateFile(rootFolder + "/app.json", generateAppJson(dataContainer, app).tabsToSpaces(4))
+            fsa.generateFile(bundlesRootFolder + "/bundles.json", generateBundleJson(dataContainer, app).tabsToSpaces(4))
             
             // Generate a separate bundle for each workflow element specified in the application model
-            for(WorkflowElement workflowElement : dataContainer.workflowElementsForApp) {
+            for(WorkflowElement workflowElement : dataContainer.workflowElementsForApp(app)) {
                 var bundleFolder = bundlesRootFolder + "/" + workflowElement.bundleName 
-                generateWorkflowElementBundle(fsa, bundleFolder, workflowElement)
+                generateWorkflowElementBundle(fsa, bundleFolder, workflowElement, app)
             }
             
-            generateModelsBundle(fsa, bundlesRootFolder + "/md2_models")
-            generateContentProvidersBundle(fsa, bundlesRootFolder + "/md2_content_providers")
-            generateWorkflowBundle(fsa, bundlesRootFolder + "/md2_workflow")
+            generateModelsBundle(fsa, bundlesRootFolder + "/md2_models", app)
+            generateContentProvidersBundle(fsa, bundlesRootFolder + "/md2_content_providers", app)
+            generateWorkflowBundle(fsa, bundlesRootFolder + "/md2_workflow", app)
             
             /////////////////////////////////////////
             // Build zip file for application
@@ -65,10 +64,10 @@ class MapAppsGenerator extends AbstractPlatformGenerator {
 	 * All custom actions are inserted into a separate folder called "actions".
 	 */
 	
-	def generateWorkflowElementBundle(IExtendedFileSystemAccess fsa, String bundleFolder, WorkflowElement workflowElement) {
+	def generateWorkflowElementBundle(IExtendedFileSystemAccess fsa, String bundleFolder, WorkflowElement workflowElement, App app) {
 		fsa.generateFile(bundleFolder + "/module.js", generateModuleForWorkflowElement().tabsToSpaces(4))
 		
-		fsa.generateFile(bundleFolder + "/manifest.json", generateManifestJsonForWorkflowElement(workflowElement, dataContainer).tabsToSpaces(4))
+		fsa.generateFile(bundleFolder + "/manifest.json", generateManifestJsonForWorkflowElement(workflowElement, dataContainer, app).tabsToSpaces(4))
 		
 		fsa.generateFile(bundleFolder + "/Controller.js", generateController(dataContainer).tabsToSpaces(4))
 		
@@ -86,10 +85,10 @@ class MapAppsGenerator extends AbstractPlatformGenerator {
 	 * All entities and enums specified in the application model are inserted into a separate folder called "models".
 	 */	
 	
-	def generateModelsBundle(IExtendedFileSystemAccess fsa, String modelBundleFolder){
+	def generateModelsBundle(IExtendedFileSystemAccess fsa, String modelBundleFolder, App app){
 		fsa.generateFile(modelBundleFolder + "/module.js", generateModuleForModels().tabsToSpaces(4))
 		
-		fsa.generateFile(modelBundleFolder + "/manifest.json", generateManifestJsonForModels(dataContainer).tabsToSpaces(4))
+		fsa.generateFile(modelBundleFolder + "/manifest.json", generateManifestJsonForModels(dataContainer, app).tabsToSpaces(4))
 		
 		fsa.generateFile(modelBundleFolder + "/Models.js", generateModelsInterface(dataContainer).tabsToSpaces(4))
 		
@@ -108,24 +107,24 @@ class MapAppsGenerator extends AbstractPlatformGenerator {
 	 * workflow elements based on events fired by workflow elements.
 	 * The bundle contains its own manifest.json, module.js and a class called WorkflowEventHandler.js.
 	 */	
-	def generateWorkflowBundle(IExtendedFileSystemAccess fsa, String workflowBundleFolder){
+	def generateWorkflowBundle(IExtendedFileSystemAccess fsa, String workflowBundleFolder, App app){
 		fsa.generateFile(workflowBundleFolder + "/module.js", generateModuleForWorkflowHandler().tabsToSpaces(4))
 		
-		fsa.generateFile(workflowBundleFolder + "/manifest.json", generateManifestJsonForWorkflowHandler(dataContainer).tabsToSpaces(4))
+		fsa.generateFile(workflowBundleFolder + "/manifest.json", generateManifestJsonForWorkflowHandler(dataContainer, app).tabsToSpaces(4))
 		
-		fsa.generateFile(workflowBundleFolder + "/WorkflowEventHandler.js", generateWorkflowEventHandler(dataContainer).tabsToSpaces(4))
+		fsa.generateFile(workflowBundleFolder + "/WorkflowEventHandler.js", generateWorkflowEventHandler(dataContainer, app).tabsToSpaces(4))
 	}
 	
 	/* Generate a bundle for the content providers specified in the application model.  
 	 * This bundle contains its own manifest.json, module.js and Models.js. and a folder in which all content providers are inserted.
 	 */	
-	def generateContentProvidersBundle (IExtendedFileSystemAccess fsa, String contentProviderBundleFolder){
+	def generateContentProvidersBundle (IExtendedFileSystemAccess fsa, String contentProviderBundleFolder, App app){
 		fsa.generateFile(contentProviderBundleFolder + "/module.js", generateModuleForContentProviders(dataContainer).tabsToSpaces(4))
-		fsa.generateFile(contentProviderBundleFolder + "/manifest.json", generateManifestJsonForContentProviders(dataContainer).tabsToSpaces(4))
+		fsa.generateFile(contentProviderBundleFolder + "/manifest.json", generateManifestJsonForContentProviders(dataContainer, app).tabsToSpaces(4))
 		
 		//put all content providers in the in an additional folder called "contentproviders"
 		for (contentProvider : dataContainer.contentProviders) {
-			fsa.generateFile(contentProviderBundleFolder + "/contentproviders/" + contentProvider.name.toFirstUpper + ".js", generateContentProvider(contentProvider, dataContainer).tabsToSpaces(4))
+			fsa.generateFile(contentProviderBundleFolder + "/contentproviders/" + contentProvider.name.toFirstUpper + ".js", generateContentProvider(contentProvider, dataContainer, app).tabsToSpaces(4))
 		}
 	}
 	

--- a/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/util/DataContainer.xtend
+++ b/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/util/DataContainer.xtend
@@ -106,13 +106,6 @@ class DataContainer {
 	
 	
 	/**
-	 * Stores a reference to the current app.
-	 */
-	@Property
-	private App app
-	
-	
-	/**
 	 * Initializes the sets offered by the data container
 	 */
 	new(ResourceSet input) {
@@ -243,10 +236,7 @@ class DataContainer {
 	/**
 	 * Returns all workflows associated with the current app.
 	 */
-	def public workflowElementsForApp() {
-	    if(app == null){
-	        throw new IllegalStateException("No app has been set for the DataContainer.")
-	    }
+	def public workflowElementsForApp(App app) {
 	    val wfes = app.workflowElements.map[it.workflowElementReference].toSet
 	    return wfes
 	}

--- a/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/util/DataContainer.xtend
+++ b/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/util/DataContainer.xtend
@@ -21,7 +21,6 @@ import static de.wwu.md2.framework.generator.util.MD2GeneratorUtil.*import de.w
 import de.wwu.md2.framework.mD2.App
 import de.wwu.md2.framework.mD2.WorkflowElement
 import java.util.Map
-import java.util.HashMap
 import de.wwu.md2.framework.mD2.EventBindingTask
 import de.wwu.md2.framework.mD2.SimpleActionRef
 import de.wwu.md2.framework.mD2.FireEventAction
@@ -40,16 +39,16 @@ class DataContainer {
 	///////////////////////////////////////
 	
 	@Property
-	private Collection<View> views
+	private View view
 	
 	@Property
-	private Collection<Controller> controllers
+	private Controller controller
 	
 	@Property
-	private Collection<Model> models
+	private Model model
 	
 	@Property
-	private Collection<Workflow> workflows
+	private Workflow workflow
 	
 	
 	///////////////////////////////////////
@@ -107,6 +106,13 @@ class DataContainer {
 	
 	
 	/**
+	 * Stores a reference to the current app.
+	 */
+	@Property
+	private App app
+	
+	
+	/**
 	 * Initializes the sets offered by the data container
 	 */
 	new(ResourceSet input) {
@@ -130,11 +136,6 @@ class DataContainer {
 	 */
 	def private intializeModelTypedLists(ResourceSet input) {
 		
-		views = newHashSet()
-		controllers = newHashSet()
-		models = newHashSet()
-		workflows = newHashSet()
-		
 		val md2models = input.resources.map[ r |
 			r.contents.filter(MD2Model)
 		].flatten
@@ -142,10 +143,10 @@ class DataContainer {
 		md2models.forEach[ md2model |
 			val modelLayer = md2model.modelLayer
 			switch modelLayer {
-				View : views.add(modelLayer)
-				Model : models.add(modelLayer)
-				Controller : controllers.add(modelLayer)
-				Workflow : workflows.add(modelLayer)
+				View : view = modelLayer
+				Model : model = modelLayer
+				Controller : controller = modelLayer
+				Workflow : workflow = modelLayer
 			}
 		]
 	}
@@ -155,9 +156,7 @@ class DataContainer {
 	 * and app version without iterating over the object tree over and over again.
 	 */
 	def private extractUniqueMain() {
-		main = controllers.map[ ctrl |
-			ctrl.controllerElements.filter(Main)
-		].flatten.head
+	    main = controller.controllerElements.filter(Main).head
 	}
 	
 	/**
@@ -169,21 +168,12 @@ class DataContainer {
 		remoteValidators = newHashSet
 		workflowElements = newHashSet
 		
-		customActions = controllers.map[ ctrl |
-			ctrl.controllerElements.filter(CustomAction)
-		].flatten.toSet
+		var ce = controller.controllerElements 
 		
-		contentProviders = controllers.map[ ctrl |
-			ctrl.controllerElements.filter(ContentProvider)
-		].flatten.toSet
-		
-		remoteValidators = controllers.map[ ctrl |
-			ctrl.controllerElements.filter(RemoteValidator)
-		].flatten.toSet
-		
-		workflowElements = controllers.map[ ctrl | 
-			ctrl.controllerElements.filter(WorkflowElement)
-		].flatten.toSet
+		customActions     = ce.filter(CustomAction).toSet
+		contentProviders  = ce.filter(ContentProvider).toSet
+		remoteValidators  = ce.filter(RemoteValidator).toSet
+		workflowElements  = ce.filter(WorkflowElement).toSet
 	}
 	
 	/**
@@ -193,13 +183,8 @@ class DataContainer {
 		entities = newHashSet
 		enums = newHashSet
 		
-		entities = models.map[ model |
-			model.modelElements.filter(Entity)
-		].flatten.toSet
-		
-		enums = models.map[ model |
-			model.modelElements.filter(Enum)
-		].flatten.toSet
+		entities = model.modelElements.filter(Entity).toSet
+		enums = model.modelElements.filter(Enum).toSet
 	}
 	
 	/**
@@ -237,15 +222,12 @@ class DataContainer {
 	 */
 	def private extractElementsFromWorkflows() {
 		apps = newHashSet
-		
-		apps = workflows.map[ workflow |
-			 workflow.apps
-		].flatten.toSet
+		apps = workflow.apps.toSet
 	}
 	
 	
-	def public getEventsFromWorkflowElement(WorkflowElement wfe)
-	{
+	def public getEventsFromWorkflowElement(WorkflowElement wfe) {
+	    
 		var customActions = wfe.actions.filter(CustomAction).map[custAction | custAction.codeFragments].flatten.toSet
 		
 		var actions = customActions.filter(EventBindingTask).map[tasks | tasks.actions].flatten.toSet
@@ -258,4 +240,14 @@ class DataContainer {
 	}
 	
 	
+	/**
+	 * Returns all workflows associated with the current app.
+	 */
+	def public workflowElementsForApp() {
+	    if(app == null){
+	        throw new IllegalStateException("No app has been set for the DataContainer.")
+	    }
+	    val wfes = app.workflowElements.map[it.workflowElementReference].toSet
+	    return wfes
+	}
 }


### PR DESCRIPTION
- Simplify DataContainer: only one model, workflow, view and controller
- Loop over all apps found in the preprocessed model
- Remove usage of ResourceSet in generator (because all important resources are in the DataContainer anyway)
- Get workflows of current app only
