### PR TITLE
Check that cloned view elements belong to the workflow element.

### DIFF
--- a/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/preprocessor/MD2Preprocessor.xtend
+++ b/de.wwu.md2.framework/src/de/wwu/md2/framework/generator/preprocessor/MD2Preprocessor.xtend
@@ -168,9 +168,9 @@ class MD2Preprocessor extends AbstractPreprocessor {
 			
 			viewReferences.copyAllCustomCodeFragmentsToClonedGUIElements(clonedElements, clonedCodeFragments, wfe) // done
 		
-			viewReferences.removeAllCustomCodeFragmentsThatReferenceUnusedGUIElements(clonedCodeFragments, wfe) // done
 		]
 		
+        viewReferences.removeAllCustomCodeFragmentsThatReferenceUnusedGUIElements(clonedCodeFragments) // done
 		
 		view.transformInputsWithLabelsAndTooltipsToLayouts // done
 		


### PR DESCRIPTION
Some parts of the preprocessor are built with only a single controller in mind. Here, I added a filter to ensure that only the mappings for view elements that really belong to a workflowElement are created. This is probably  more of a short-term fix than a long-term solution.
