### PR TITLE
Bug/internal entity validator

### DIFF
--- a/de.wwu.md2.framework.tests/models/de/wwu/md2/framework/tests/dsl/model/validator/ENameReservedNameValidatorModel.md2
+++ b/de.wwu.md2.framework.tests/models/de/wwu/md2/framework/tests/dsl/model/validator/ENameReservedNameValidatorModel.md2
@@ -1,0 +1,6 @@
+package TestProject.models
+
+entity WorkflowState {
+    att1: string
+    att2: string
+}

--- a/de.wwu.md2.framework.tests/models/de/wwu/md2/framework/tests/dsl/model/validator/ENameUnderscoreValidatorModel.md2
+++ b/de.wwu.md2.framework.tests/models/de/wwu/md2/framework/tests/dsl/model/validator/ENameUnderscoreValidatorModel.md2
@@ -1,0 +1,6 @@
+package TestProject.models
+
+entity _Default {
+    att1: string
+    att2: string
+}

--- a/de.wwu.md2.framework.tests/src/de/wwu/md2/framework/tests/dsl/model/validator/Validator_Model_Test.xtend
+++ b/de.wwu.md2.framework.tests/src/de/wwu/md2/framework/tests/dsl/model/validator/Validator_Model_Test.xtend
@@ -21,13 +21,15 @@ class Validator_Model_Test {
 	
 	@Inject extension ParseHelper<MD2Model>
 	@Inject extension ValidationTestHelper
-	MD2Model defaultReferenceValue;
-	MD2Model entityEnumUppercase;
-	MD2Model attributeLowercase;
-	MD2Model repeatedParameter;
-	MD2Model unsupportedFeatures;
+	MD2Model defaultReferenceValue
+	MD2Model entityEnumUppercase
+	MD2Model attributeLowercase
+	MD2Model repeatedParameter
+	MD2Model unsupportedFeatures
+	MD2Model underscoreWithinEntityName
+	MD2Model reservedNameWithinEntity
 	
-	ResourceSet rs;
+	ResourceSet rs
 	
 	@Before
 	def void setUp() {
@@ -37,6 +39,8 @@ class Validator_Model_Test {
 		attributeLowercase = MODEL_VALIDATOR_LOWERCASE_ATTRIBUTE.load.parse
 		repeatedParameter = MODEL_VALIDATOR_REPEATED_PARAMETERS.load.parse
 		unsupportedFeatures = MODEL_VALIDATOR_UNSUPPORTED_FEATURES.load.parse
+		underscoreWithinEntityName = MODEL_VALIDATOR_UNDERSCORE_ENTITY.load.parse
+		reservedNameWithinEntity = MODEL_VALIDATOR_RESERVEDNAME_ENTITY.load.parse
 	}
 	
 	/**
@@ -79,4 +83,20 @@ class Validator_Model_Test {
 	def checkAttributeTypeParam() {
 	    unsupportedFeatures.assertWarning(MD2Package::eINSTANCE.attributeTypeParam, ModelValidator::UNSUPPORTEDPARAMTYPE)
 	}
+	
+	/**
+	 * Checks whether the error for underscores at the beginning of entities is thrown.
+	 */
+	 @Test
+	 def checkUnderscoreEntityNameValidator(){
+	 	underscoreWithinEntityName.assertError(MD2Package::eINSTANCE.modelElement, ModelValidator::ENTITYWITHOUTUNDERSCORE)
+	 }
+	 
+	 /**
+	 * Checks whether the error for preset Names as entities is thrown.
+	 */
+	 @Test
+	 def checkPresetIdentifiersAsEntityNameValidator(){
+	 	reservedNameWithinEntity.assertError(MD2Package::eINSTANCE.modelElement, ModelValidator::ENTITYWITHRESERVEDNAME)
+	 }
 }

--- a/de.wwu.md2.framework.tests/src/de/wwu/md2/framework/tests/dsl/project/validator/ModelElementPackageCongruenceTest.xtend
+++ b/de.wwu.md2.framework.tests/src/de/wwu/md2/framework/tests/dsl/project/validator/ModelElementPackageCongruenceTest.xtend
@@ -23,9 +23,9 @@ class ModelElementPackageCongruenceTest {
     @Inject extension ParseHelper<MD2Model>
     @Inject extension ValidationTestHelper
     
-    MD2Model controllerModel;
-    MD2Model modelModel;
-    MD2Model viewModel;
+    MD2Model controllerModel
+    MD2Model modelModel
+    MD2Model viewModel
     MD2Model workflowModel
     MD2Model testModel
 

--- a/de.wwu.md2.framework.tests/src/de/wwu/md2/framework/tests/utils/ModelProvider.java
+++ b/de.wwu.md2.framework.tests/src/de/wwu/md2/framework/tests/utils/ModelProvider.java
@@ -75,6 +75,9 @@ public class ModelProvider {
 	public static final String MODEL_VALIDATOR_REPEATED_PARAMETERS = "dsl/model/validator/RepeatedParameters.md2";
 	public static final String MODEL_VALIDATOR_UNSUPPORTED_FEATURES = "dsl/model/validator/UnsupportedFeatures.md2";
 	public static final String MODEL_VALIDATOR_UPPERCASE_ENTITY = "dsl/model/validator/UppercaseEntity.md2";
+	
+	public static final String MODEL_VALIDATOR_UNDERSCORE_ENTITY = "dsl/model/validator/ENameUnderscoreValidatorModel.md2";
+	public static final String MODEL_VALIDATOR_RESERVEDNAME_ENTITY = "dsl/model/validator/ENameReservedNameValidatorModel.md2";
 
 	/** views **/
 	public static final String CONTENT_CONTAINER_FLOW_LAYOUT_V = "dsl/view/viewGuiElement/containerElement/contentContainer/flowLayoutPane.md2";

--- a/de.wwu.md2.framework.ui/src/de/wwu/md2/framework/ui/quickfix/MD2QuickfixProvider.java
+++ b/de.wwu.md2.framework.ui/src/de/wwu/md2/framework/ui/quickfix/MD2QuickfixProvider.java
@@ -1,19 +1,27 @@
 
 package de.wwu.md2.framework.ui.quickfix;
 
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.ui.editor.model.edit.IModificationContext;
+import org.eclipse.xtext.ui.editor.model.edit.ISemanticModification;
 import org.eclipse.xtext.ui.editor.quickfix.DefaultQuickfixProvider;
+import org.eclipse.xtext.ui.editor.quickfix.Fix;
+import org.eclipse.xtext.ui.editor.quickfix.IssueResolutionAcceptor;
+import org.eclipse.xtext.validation.Issue;
+
+import de.wwu.md2.framework.mD2.Entity;
+import de.wwu.md2.framework.validation.ModelValidator;
 
 public class MD2QuickfixProvider extends DefaultQuickfixProvider {
 
-//	@Fix(MyJavaValidator.INVALID_NAME)
-//	public void capitalizeName(final Issue issue, IssueResolutionAcceptor acceptor) {
-//		acceptor.accept(issue, "Capitalize name", "Capitalize the name.", "upcase.png", new IModification() {
-//			public void apply(IModificationContext context) throws BadLocationException {
-//				IXtextDocument xtextDocument = context.getXtextDocument();
-//				String firstLetter = xtextDocument.get(issue.getOffset(), 1);
-//				xtextDocument.replace(issue.getOffset(), 1, firstLetter.toUpperCase());
-//			}
-//		});
-//	}
-
+	@Fix(ModelValidator.ENTITYWITHOUTUNDERSCORE)
+	public void deleteUnderscoreFromEntityname(final Issue issue, IssueResolutionAcceptor acceptor){
+		acceptor.accept(issue, "Delete underscore", "Deletes the underscore from the entity/enum identifier.", "upcase.png", new ISemanticModification() {
+			public void apply(EObject element, IModificationContext context) {
+				Entity entity = ((Entity) element);
+				entity.setName(entity.getName().substring(1));
+			}
+		});
+	}
+	
 }

--- a/de.wwu.md2.framework/src/de/wwu/md2/framework/validation/ModelValidator.xtend
+++ b/de.wwu.md2.framework/src/de/wwu/md2/framework/validation/ModelValidator.xtend
@@ -80,17 +80,19 @@ class ModelValidator extends AbstractMD2JavaValidator {
      /**
      * Prevent from using the following preset identifiers as entity / enum names:
      * - WorkflowState
+     * - EventHandler
+     * - VersionNegotiation,
+     * since these names will conflict during generation of entities and webservices, e.g. on the backend.
      */
      @Check
      def checkEntityNameDoesntEqualPresetIdentifiers(ModelElement modelElement){
      	// Add new preset identifiers to the List, if they should also be excluded within the entity / enum names
-     	var presetIdentifiers = newArrayList("WorkflowState")
+     	var presetIdentifiers = newHashSet("WorkflowState", "EventHandler", "VersionNegotiation")
      	// for every preset identifier, check if used as entity / enum name --> then error
-		for (identifier : presetIdentifiers ){
-			if(modelElement.name == identifier){
-     			error(identifier+" shouldn't be used as an entity / enum name, since it is a preset identifier.", MD2Package.eINSTANCE.modelElement_Name, ENTITYWITHRESERVEDNAME);
-     		}
-		}
+     	
+		if(presetIdentifiers.contains(modelElement.name)){
+ 			error(presetIdentifiers+" shouldn't be used as an entity / enum name, since it is a preset identifier.", MD2Package.eINSTANCE.modelElement_Name, ENTITYWITHRESERVEDNAME);
+ 		}
      }
 	
 	/**

--- a/de.wwu.md2.framework/src/de/wwu/md2/framework/validation/ModelValidator.xtend
+++ b/de.wwu.md2.framework/src/de/wwu/md2/framework/validation/ModelValidator.xtend
@@ -29,6 +29,7 @@ class ModelValidator extends AbstractMD2JavaValidator {
     public static final String DEFAULTREFERENCEVALUE = "defaultReferenceValue"
     public static final String ENTITYENUMUPPERCASE = "entityEnumUppercase"
     public static final String ENTITYWITHOUTUNDERSCORE = "entityWithoutUnderscore"
+    public static final String ENTITYWITHRESERVEDNAME = "entityWithReservedName"
     public static final String ATTRIBUTELOWERCASE = "attributeLowercase"
     public static final String REPEATEDPARAMS = "repeatedParams"
     public static final String UNSUPPORTEDPARAMTYPE = "unsupportedParamType"
@@ -87,7 +88,7 @@ class ModelValidator extends AbstractMD2JavaValidator {
      	// for every preset identifier, check if used as entity / enum name --> then error
 		for (identifier : presetIdentifiers ){
 			if(modelElement.name == identifier){
-     			error(identifier+" shouldn't be used as an entity / enum name, since it is a preset identifier.", MD2Package.eINSTANCE.modelElement_Name);
+     			error(identifier+" shouldn't be used as an entity / enum name, since it is a preset identifier.", MD2Package.eINSTANCE.modelElement_Name, ENTITYWITHRESERVEDNAME);
      		}
 		}
      }

--- a/de.wwu.md2.framework/src/de/wwu/md2/framework/validation/ModelValidator.xtend
+++ b/de.wwu.md2.framework/src/de/wwu/md2/framework/validation/ModelValidator.xtend
@@ -1,17 +1,17 @@
 package de.wwu.md2.framework.validation
 
+import com.google.common.collect.Sets
 import com.google.inject.Inject
 import de.wwu.md2.framework.mD2.AttrEnumDefault
-import de.wwu.md2.framework.mD2.Entity
-import de.wwu.md2.framework.mD2.ReferencedType
-import org.eclipse.xtext.validation.Check
-import org.eclipse.xtext.validation.EValidatorRegistrar
-import de.wwu.md2.framework.mD2.ModelElement
-import de.wwu.md2.framework.mD2.MD2Package
 import de.wwu.md2.framework.mD2.Attribute
 import de.wwu.md2.framework.mD2.AttributeType
 import de.wwu.md2.framework.mD2.AttributeTypeParam
-import com.google.common.collect.Sets
+import de.wwu.md2.framework.mD2.Entity
+import de.wwu.md2.framework.mD2.MD2Package
+import de.wwu.md2.framework.mD2.ModelElement
+import de.wwu.md2.framework.mD2.ReferencedType
+import org.eclipse.xtext.validation.Check
+import org.eclipse.xtext.validation.EValidatorRegistrar
 
 /**
  * Validators for all model elements of MD2.
@@ -74,6 +74,22 @@ class ModelValidator extends AbstractMD2JavaValidator {
      	if(modelElement.name.charAt(0).equals(new Character ('_'))){
      		error("Entity and Enum identifiers shouldn't start with an underscore.",MD2Package.eINSTANCE.modelElement_Name,ENTITYWITHOUTUNDERSCORE);
      	}
+     }
+     
+     /**
+     * Prevent from using the following preset identifiers as entity / enum names:
+     * - WorkflowState
+     */
+     @Check
+     def checkEntityNameDoesntEqualPresetIdentifiers(ModelElement modelElement){
+     	// Add new preset identifiers to the List, if they should also be excluded within the entity / enum names
+     	var presetIdentifiers = newArrayList("WorkflowState")
+     	// for every preset identifier, check if used as entity / enum name --> then error
+		for (identifier : presetIdentifiers ){
+			if(modelElement.name == identifier){
+     			error(identifier+" shouldn't be used as an entity / enum name, since it is a preset identifier.", MD2Package.eINSTANCE.modelElement_Name);
+     		}
+		}
      }
 	
 	/**

--- a/de.wwu.md2.framework/src/de/wwu/md2/framework/validation/ModelValidator.xtend
+++ b/de.wwu.md2.framework/src/de/wwu/md2/framework/validation/ModelValidator.xtend
@@ -28,6 +28,7 @@ class ModelValidator extends AbstractMD2JavaValidator {
     
     public static final String DEFAULTREFERENCEVALUE = "defaultReferenceValue"
     public static final String ENTITYENUMUPPERCASE = "entityEnumUppercase"
+    public static final String ENTITYWITHOUTUNDERSCORE = "entityWithoutUnderscore"
     public static final String ATTRIBUTELOWERCASE = "attributeLowercase"
     public static final String REPEATEDPARAMS = "repeatedParams"
     public static final String UNSUPPORTEDPARAMTYPE = "unsupportedParamType"
@@ -64,6 +65,16 @@ class ModelValidator extends AbstractMD2JavaValidator {
             warning("Entity and Enum identifiers should start with an upper case letter", MD2Package.eINSTANCE.modelElement_Name, -1, ENTITYENUMUPPERCASE);
         }
     }
+    
+    /**
+     * Prevent from using an underscore "_" in the beginning of an entity name
+     */
+     @Check
+     def checkEntityDoesntStartWithUnderscore(ModelElement modelElement){
+     	if(modelElement.name.charAt(0).equals(new Character ('_'))){
+     		error("Entity and Enum identifiers shouldn't start with an underscore.",MD2Package.eINSTANCE.modelElement_Name,ENTITYWITHOUTUNDERSCORE);
+     	}
+     }
 	
 	/**
      * Enforce conventions:


### PR DESCRIPTION
Fixes the bug, that preset identifiers and underscores could be set as names for entities / enums.

Added methods:
- Validator for underscores
- Quickfix for underscores (deletes them)
- Validator against list of preset names
